### PR TITLE
Add workflow query benchmark example

### DIFF
--- a/mtls/client.go
+++ b/mtls/client.go
@@ -1,0 +1,60 @@
+package mtls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"os"
+
+	"go.temporal.io/sdk/client"
+)
+
+func ParseClientOptionFlags(args []string) (client.Options, string, error) {
+	// Parse args
+	set := flag.NewFlagSet("hello-world-mtls", flag.ContinueOnError)
+	targetHost := set.String("target-host", "localhost:7233", "Host:port for the server")
+	namespace := set.String("namespace", "default", "Namespace for the server")
+	serverRootCACert := set.String("server-root-ca-cert", "", "Optional path to root server CA cert")
+	clientCert := set.String("client-cert", "", "Required path to client cert")
+	clientKey := set.String("client-key", "", "Required path to client key")
+	serverName := set.String("server-name", "", "Server name to use for verifying the server's certificate")
+	insecureSkipVerify := set.Bool("insecure-skip-verify", false, "Skip verification of the server's certificate and host name")
+	input := set.String("i", "{}", "Workflow input parameters.")
+	if err := set.Parse(args); err != nil {
+		return client.Options{}, "", fmt.Errorf("failed parsing args: %w", err)
+	} else if *clientCert == "" || *clientKey == "" {
+		return client.Options{}, "", fmt.Errorf("-client-cert and -client-key are required")
+	}
+
+	// Load client cert
+	cert, err := tls.LoadX509KeyPair(*clientCert, *clientKey)
+	if err != nil {
+		return client.Options{}, "", fmt.Errorf("failed loading client cert and key: %w", err)
+	}
+
+	// Load server CA if given
+	var serverCAPool *x509.CertPool
+	if *serverRootCACert != "" {
+		serverCAPool = x509.NewCertPool()
+		b, err := os.ReadFile(*serverRootCACert)
+		if err != nil {
+			return client.Options{}, "", fmt.Errorf("failed reading server CA: %w", err)
+		} else if !serverCAPool.AppendCertsFromPEM(b) {
+			return client.Options{}, "", fmt.Errorf("server CA PEM file invalid")
+		}
+	}
+
+	return client.Options{
+		HostPort:  *targetHost,
+		Namespace: *namespace,
+		ConnectionOptions: client.ConnectionOptions{
+			TLS: &tls.Config{
+				Certificates:       []tls.Certificate{cert},
+				RootCAs:            serverCAPool,
+				ServerName:         *serverName,
+				InsecureSkipVerify: *insecureSkipVerify,
+			},
+		},
+	}, *input, nil
+}

--- a/query-bench/README.md
+++ b/query-bench/README.md
@@ -1,0 +1,38 @@
+This is a basic example to benchmark workflow queries against Temporal Cloud.
+
+Steps to run this sample:
+
+1. Run the following command to start a worker
+```
+go run query-bench/worker/main.go \
+    -target-host "<namespace>.tmprl.cloud:7233" \
+    -namespace "<namespace>" \
+    -client-cert "<cert path>" \
+    -client-key "<key path>"
+```
+
+2. Run the following command to trigger 50 workflow executions.
+```
+for wid in {1..50}
+do
+  go run query-bench/starter/main.go \
+    -target-host "<namespace>.tmprl.cloud:7233" \
+    -namespace "<namespace>" \
+    -client-cert "<cert path>" \
+    -client-key "<key path>" \
+    -i "${wid}"
+done
+```
+This command will take a while to run since each execution is creating 500 activities
+
+3. Run the following command to query the workflow based on the wid, e.g. 1
+```
+wid=1
+go run query-bench/query/main.go \
+    -target-host "<namespace>.tmprl.cloud:7233" \
+    -namespace "<namespace>" \
+    -client-cert "<cert path>" \
+    -client-key "<key path>" \
+    -i "${wid}"
+```
+By default, the query runs in 20 concurrent goroutines with each making 10 queries. RPS is shown at the end.

--- a/query-bench/query/main.go
+++ b/query-bench/query/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/temporalio/samples-go/mtls"
+	query "github.com/temporalio/samples-go/query-bench"
+	"go.temporal.io/sdk/client"
+)
+
+const (
+	queryType   = "state"
+	concurrency = 20
+	requests    = 50
+)
+
+func main() {
+	// The client is a heavyweight object that should be created once per process.
+	clientOptions, wid, err := mtls.ParseClientOptionFlags(os.Args[1:])
+	if err != nil {
+		log.Fatalf("Invalid arguments: %v", err)
+	}
+	c, err := client.Dial(clientOptions)
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	then := time.Now()
+	test(c, wid)
+	fmt.Printf("\nTime elapsed: %v\n", time.Since(then))
+	fmt.Printf("Total queries: %v\n", concurrency*requests)
+	fmt.Printf("RPS: %v\n", concurrency*requests/time.Since(then).Seconds())
+}
+
+func test(c client.Client, wid string) {
+	var wg sync.WaitGroup
+	for i := 1; i <= concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 1; j <= requests; j++ {
+				resp, err := c.QueryWorkflow(context.Background(), query.WorkflowIDPrefix+wid, "", queryType)
+				if err != nil {
+					log.Fatalln("Unable to query workflow", err)
+				}
+				var result interface{}
+				if err := resp.Get(&result); err != nil {
+					log.Fatalln("Unable to decode query result", err)
+				}
+				fmt.Print(".")
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/query-bench/query_workflow.go
+++ b/query-bench/query_workflow.go
@@ -1,0 +1,53 @@
+package query
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	numActivities    = 500 // this should produce ~1500 events
+	sleepMinutes     = 60
+	WorkflowIDPrefix = "query_workflow_"
+)
+
+// Workflow is to demo how to setup query handler
+func QueryWorkflow(ctx workflow.Context) error {
+	err := workflow.SetQueryHandler(ctx, "state", func(input []byte) (string, error) {
+		return "hello", nil
+	})
+
+	logger := workflow.GetLogger(ctx)
+	logger.Info("QueryWorkflow started")
+
+	var result string
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Second,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	for i := 1; i < numActivities; i++ {
+		logger.Info("Starting activity 1")
+		err = workflow.ExecuteActivity(ctx, Activity, "Hello").Get(ctx, &result)
+		if err != nil {
+			logger.Error("Activity failed.", "Error", err)
+			return err
+		}
+	}
+
+	logger.Info(fmt.Sprintf("Putting workflow to sleep for %s minutes", sleepMinutes))
+	_ = workflow.Sleep(ctx, sleepMinutes*time.Minute)
+
+	logger.Info("Workflow completed")
+	return nil
+}
+
+func Activity(ctx context.Context, name string) (string, error) {
+	logger := activity.GetLogger(ctx)
+	logger.Info("Activity", "name", name)
+	return "Hello " + name + "!", nil
+}

--- a/query-bench/query_workflow_test.go
+++ b/query-bench/query_workflow_test.go
@@ -1,0 +1,35 @@
+package query
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
+)
+
+func Test_QueryWorkflow(t *testing.T) {
+	ts := &testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	w := false
+	env.RegisterDelayedCallback(func() {
+		queryAndVerify(t, env, "waiting on timer")
+		w = true
+	}, time.Minute*1)
+
+	env.ExecuteWorkflow(QueryWorkflow)
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.True(t, w, "state at timer not verified")
+	queryAndVerify(t, env, "done")
+}
+
+func queryAndVerify(t *testing.T, env *testsuite.TestWorkflowEnvironment, expectedState string) {
+	result, err := env.QueryWorkflow("state")
+	require.NoError(t, err)
+	var state string
+	err = result.Get(&state)
+	require.NoError(t, err)
+	require.Equal(t, expectedState, state)
+}

--- a/query-bench/starter/main.go
+++ b/query-bench/starter/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"go.temporal.io/sdk/client"
+
+	"github.com/temporalio/samples-go/mtls"
+	query "github.com/temporalio/samples-go/query-bench"
+)
+
+func main() {
+	// The client is a heavyweight object that should be created once per process.
+	clientOptions, wid, err := mtls.ParseClientOptionFlags(os.Args[1:])
+	if err != nil {
+		log.Fatalf("Invalid arguments: %v", err)
+	}
+	c, err := client.Dial(clientOptions)
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	workflowOptions := client.StartWorkflowOptions{
+		ID:        query.WorkflowIDPrefix + wid,
+		TaskQueue: "query",
+	}
+
+	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, query.QueryWorkflow)
+	if err != nil {
+		log.Fatalln("Unable to execute workflow", err)
+	}
+	log.Println("Started workflow", "WorkflowID", we.GetID(), "RunID", we.GetRunID())
+}

--- a/query-bench/worker/main.go
+++ b/query-bench/worker/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+
+	"github.com/temporalio/samples-go/mtls"
+	query "github.com/temporalio/samples-go/query-bench"
+)
+
+func main() {
+	// The client and worker are heavyweight objects that should be created once per process.
+	clientOptions, _, err := mtls.ParseClientOptionFlags(os.Args[1:])
+	if err != nil {
+		log.Fatalf("Invalid arguments: %v", err)
+	}
+	c, err := client.Dial(clientOptions)
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	defer c.Close()
+
+	worker.EnableVerboseLogging(true)
+
+	w := worker.New(c, "query", worker.Options{MaxConcurrentWorkflowTaskPollers: 10})
+
+	w.RegisterWorkflow(query.QueryWorkflow)
+	w.RegisterActivity(query.Activity)
+
+	err = w.Run(worker.InterruptCh())
+	if err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}


### PR DESCRIPTION
This is a basic example to benchmark workflow queries against Temporal Cloud.

Steps to run this sample:

1. Run the following command to start worker
```
go run query-bench/worker/main.go \
    -target-host "<namespace>.tmprl.cloud:7233" \
    -namespace "<namespace>" \
    -client-cert "<cert path>" \
    -client-key "<key path>"
```

2. Run the following command to trigger a number of workflow execution.
```
for wid in {1..50}
do
  go run query-bench/starter/main.go \
    -target-host "<namespace>.tmprl.cloud:7233" \
    -namespace "<namespace>" \
    -client-cert "<cert path>" \
    -client-key "<key path>" \
    -i "${wid}"
done
```
This command will take a while to run since each execution is creating 500 activities

3. Run the following command to query the workflow based on the wid
```
wid=1
go run query-bench/query/main.go \
    -target-host "<namespace>.tmprl.cloud:7233" \
    -namespace "<namespace>" \
    -client-cert "<cert path>" \
    -client-key "<key path>" \
    -i "${wid}"
```
By default, the query runs in 50 concurrent goroutines with each making 10 queries. RPS is shown at the end.
